### PR TITLE
Webhooks to automate documentation updates

### DIFF
--- a/provisioning/roles/docs/defaults/main.yml
+++ b/provisioning/roles/docs/defaults/main.yml
@@ -46,6 +46,11 @@ docs_server_ssl_organization: Example Company
 docs_server_ssl_division: support
 docs_server_ssl_email: support@example.com
 
+# To receive webhooks when docs are updated
+docs_webhook_path: /github-notification
+docs_webhook_port: 6748
+docs_webhook_secret: default-webhook-secret
+
 # These are convenience variables with the generated base paths of the servers. You
 # most likely will never have to touch these.
 docs_server_base: "{{

--- a/provisioning/roles/docs/files/webhook_receiver/listen.js
+++ b/provisioning/roles/docs/files/webhook_receiver/listen.js
@@ -1,0 +1,30 @@
+var http = require('http')
+var createHandler = require('github-webhook-handler')
+var child_process = require('child_process');
+
+var path = process.env['WEBHOOK_PATH'] || '/webhook';
+var port = process.env['PORT'] || 7777;
+var secret = process.env['SECRET'] || 'changeme';
+
+var handler = createHandler({ path: path, secret: secret})
+
+var events = require('github-webhook-handler/events')
+Object.keys(events).forEach(function (event) {
+  console.log(event, '=', events[event])
+})
+
+http.createServer(function (req, res) {
+  handler(req, res, function (err) {
+    res.statusCode = 404
+    res.end('no such location')
+  })
+}).listen(port)
+
+handler.on('push', function (event) {
+  console.log('Received a push event for %s to %s',
+    event.payload.repository.name,
+    event.payload.ref);
+  child_process.spawn("/bin/bash", ["update.sh"]);
+})
+
+console.log("Up and listening to port", port, "path", path);

--- a/provisioning/roles/docs/files/webhook_receiver/listen.js
+++ b/provisioning/roles/docs/files/webhook_receiver/listen.js
@@ -8,11 +8,6 @@ var secret = process.env['SECRET'] || 'changeme';
 
 var handler = createHandler({ path: path, secret: secret})
 
-var events = require('github-webhook-handler/events')
-Object.keys(events).forEach(function (event) {
-  console.log(event, '=', events[event])
-})
-
 http.createServer(function (req, res) {
   handler(req, res, function (err) {
     res.statusCode = 404

--- a/provisioning/roles/docs/files/webhook_receiver/package.json
+++ b/provisioning/roles/docs/files/webhook_receiver/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "webhook-receiver",
+  "version": "0.0.1",
+  "description": "Receive github webhooks and rebuild docs",
+  "author": "Josh Mandel <joshua.mandel@childrens.harvard.edu>",
+  "dependencies": {
+    "github-webhook-handler": "0.3.4"
+  },
+  "engine": "node >= 0.6.0"
+}
+

--- a/provisioning/roles/docs/files/webhook_receiver/update.sh
+++ b/provisioning/roles/docs/files/webhook_receiver/update.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+cd ../repo
+for v in $(git for-each-ref refs/remotes/origin --format="%(refname:short)" | 
+        cut -d"/" -f2 | 
+	grep -v HEAD && 
+	git tag);
+do
+	git checkout $v;
+	echo "baseurl: /$v/" > /tmp/_config-$v.yml;
+	jekyll build --source . \
+                     --destination ../static/$v \
+		     --config _config.yml,/tmp/_config-$v.yml;
+done
+
+

--- a/provisioning/roles/docs/tasks/docs-server.yml
+++ b/provisioning/roles/docs/tasks/docs-server.yml
@@ -35,31 +35,6 @@
   sudo_user: "{{username}}"
   file: path={{install_dir}}/docs/static state=directory
   
-- name: list releases
-  tags: [docs,docs-rebuild]
-  shell: chdir={{install_dir}}/docs/repo
-         git tag
-  register: docs_releases
-   
-- name: list branches
-  tags: [docs,docs-rebuild]
-  shell: chdir={{install_dir}}/docs/repo
-         git for-each-ref refs/remotes/origin --format="%(refname:short)" | cut -d"/" -f2 | grep -v HEAD
-  register: docs_branches
-  
-- name: generate release configuration files
-  tags: [docs,docs-rebuild]
-  shell: 'echo "baseurl: /{{item}}/" > /tmp/_config-{{item}}.yml'
-  with_items: docs_releases.stdout_lines + docs_branches.stdout_lines
-  
-- name: generate docs sites
-  tags: [docs,docs-rebuild]
-  sudo_user: "{{username}}"
-  shell: 'chdir={{install_dir}}/docs/repo
-          git checkout {{item}};
-          jekyll build --source {{install_dir}}/docs/repo --destination {{install_dir}}/docs/static/{{item}} --config {{install_dir}}/docs/repo/_config.yml,/tmp/_config-{{item}}.yml'
-  with_items: docs_releases.stdout_lines + docs_branches.stdout_lines
-  
 - name: generate self-signed ssl certificate (docs server)
   tags: [docs]
   when: docs_server_secure_http and not use_custom_ssl_certificates

--- a/provisioning/roles/docs/tasks/docs-webhook.yml
+++ b/provisioning/roles/docs/tasks/docs-webhook.yml
@@ -1,0 +1,18 @@
+- name: Put update script in place
+  tags: [docs-webhook]
+  sudo_user: "{{username}}"
+  copy: src=webhook_receiver dest={{install_dir}}/docs/
+
+- name: Install npm dependencies for update script
+  tags: [docs-webhook]
+  sudo_user: "{{username}}"
+  shell: chdir={{install_dir}}/docs/webhook_receiver
+         npm install
+
+- name: Install upstart job for update script
+  tags: [docs-webhook]
+  template: src=docs-webhook.conf.j2 dest=/etc/init/docs-webhook.conf owner=root group=root mode=0644
+
+- name: restart update listener
+  tags: [docs-webhook]
+  service: name=auth-server state=restarted

--- a/provisioning/roles/docs/tasks/docs-webhook.yml
+++ b/provisioning/roles/docs/tasks/docs-webhook.yml
@@ -15,4 +15,4 @@
 
 - name: restart update listener
   tags: [docs-webhook]
-  service: name=auth-server state=restarted
+  service: name=docs-webhook state=restarted

--- a/provisioning/roles/docs/tasks/main.yml
+++ b/provisioning/roles/docs/tasks/main.yml
@@ -18,6 +18,8 @@
   with_items:
          - git
          - nginx
+         - nodejs
+         - npm
 
 - name: create group
   tags: [general]
@@ -66,3 +68,11 @@
         - restart nginx
 
 - include: docs-server.yml
+- include: docs-webhook.yml
+
+- name: generate docs sites
+  tags: [docs,docs-rebuild]
+  sudo_user: "{{username}}"
+  shell: chdir={{install_dir}}/docs/webhook_receiver
+         /bin/bash update.sh
+ 

--- a/provisioning/roles/docs/templates/docs-webhook.conf.j2
+++ b/provisioning/roles/docs/templates/docs-webhook.conf.j2
@@ -1,0 +1,19 @@
+#!upstart
+description "Github Webhook Receiver"
+author      "Josh Mandel"
+
+setuid {{username}}
+setgid {{username}}
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+respawn limit 10 5
+
+env  WEBHOOK_PATH={{docs_webhook_path}}
+env  PORT={{docs_webhook_port}}
+env  SECRET={{docs_webhook_secret}}
+
+chdir {{install_dir}}/docs/webhook_receiver
+exec /usr/bin/nodejs listen.js


### PR DESCRIPTION
This PR helps handle auto-building documentation. The key changes are:

0. (Already merged into master) build branches as well as tags. This will support ongoing spec revisions within the Argonaut Project, where I want to have changes proposed on argonaut-specific branches and make them immediately visible through jekyll builds.

1. Add support for receiving webhooks from Github, so we can auto-build whenever an update occurs.

2. Moved the actual `jekyll`-invocation logic to an external shell script, so that Ansible and the webhook receiver can both use it. 

I've tested this on ci-docs.fhir.me.

@nschwertner: Will you do a quick review and merge if all looks ok?