### PR TITLE
Conformance endpoint no longer at /metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ vagrant up
 
 Now visit in a web browser on your local ("host") machine:
 
- * `http://localhost:9080`  for a FHIR API server
+ * `http://localhost:9080/data`  for a FHIR API server
  * `http://localhost:9085`  for an OAuth2 authorization server
  * `http://localhost:9090`  for a SMART apps server
 


### PR DESCRIPTION
Conformance exits at the endpoint `http://localhost:9080/data/metadata`
